### PR TITLE
README update to reflect react-native link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ npm install react-native-workers --save
 
 ### Automatic setup
 
-simply `rnpm link react-native-workers` and you'r good to go.
+Simply run one of the following commands and you're good to go.
+
+#### react-native >= 0.28.0
+
+simply run `react-native link`
+
+#### react-native < 0.28.0
+
+`rnpm link react-native-workers`
 
 ### Manual setup
 


### PR DESCRIPTION
As of `react-native@0.28.0`, `rnpm` is no longer needed.  See https://github.com/facebook/react-native/releases?after=v0.29.0.
